### PR TITLE
Fixes bad mailto link.

### DIFF
--- a/mailer.go
+++ b/mailer.go
@@ -11,7 +11,7 @@ import (
 
 const MAIL_TEMPLATE_NAME = "mail_template"
 const MAIL_TEMPLATE_HTML = `
-<p>This receipt confirms payment of {{.Amount | asMoney}} from <a href="{{.Email}}">{{.Email}}</a> for "{{.Reason}}".</p>
+<p>This receipt confirms payment of {{.Amount | asMoney}} from <a href="mailto:{{.Email}}">{{.Email}}</a> for "{{.Reason}}".</p>
 
 <p>If this information is incorrect, please email <a href="mailto:acm@umn.edu">acm@umn.edu</a> immediately.</p>
 `


### PR DESCRIPTION
Previously, the link with the user's email address was not a `mailto:` link, and therefore did not work.